### PR TITLE
fix(plugin): the MCP manifest spawns the console script, not bare python

### DIFF
--- a/docs/agent-json.md
+++ b/docs/agent-json.md
@@ -960,8 +960,8 @@ Client wiring:
 {
   "mcpServers": {
     "crapkit": {
-      "command": "python",
-      "args": ["-m", "crapkit", "mcp", "--repo", "/absolute/path/to/your/repo"]
+      "command": "crapkit",
+      "args": ["mcp", "--repo", "/absolute/path/to/your/repo"]
     }
   }
 }

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "crapkit": {
-      "command": "python",
-      "args": ["-m", "crapkit", "mcp"]
+      "command": "crapkit",
+      "args": ["mcp"]
     }
   }
 }

--- a/tests/unit/test_plugin_manifest.py
+++ b/tests/unit/test_plugin_manifest.py
@@ -316,13 +316,16 @@ def test_every_handler_stays_async_bare_exe_and_bounded(field: str, value: objec
 
 def test_the_mcp_manifest_runs_the_subcommand_the_parser_defines():
     """`.mcp.json` lives under plugin/ so it never lands in project scope, where
-    it would raise a scope conflict for anyone developing crapkit itself."""
+    it would raise a scope conflict for anyone developing crapkit itself. It spawns
+    the console script for the same reason the hook handlers do: bare `python` on
+    Windows resolves to the WindowsApps stub and to venvs without crapkit, which
+    makes a dead MCP server with no visible error."""
     import argparse
 
     from crapkit.cli import build_parser
 
     servers = _json(MCP_JSON)["mcpServers"]
-    assert servers == {"crapkit": {"command": "python", "args": ["-m", "crapkit", "mcp"]}}
+    assert servers == {"crapkit": {"command": "crapkit", "args": ["mcp"]}}
 
     subs = [a for a in build_parser()._actions if isinstance(a, argparse._SubParsersAction)]
     assert "mcp" in subs[0].choices, "the manifest launches a subcommand argparse dropped"


### PR DESCRIPTION
## What changed

`plugin/.mcp.json` now launches the MCP server through the `crapkit` console script instead of bare `python -m crapkit`, the same resolution rule the hook handlers already use. The `docs/agent-json.md` client-wiring sample moves with it. Fixes #14: on a machine whose PATH `python` cannot import crapkit (a uv tool install, for one), the plugin's MCP server came up dead with no visible error.

## The test that proves it

`tests/unit/test_plugin_manifest.py::test_the_mcp_manifest_runs_the_subcommand_the_parser_defines`

The pin now asserts the console-script form, and its docstring carries the same Windows rationale the hook-handler pin documents. On main the updated assertion fails against the old manifest.

## Checks

- [ ] crapkit's own gate did not run on this commit: the clone had no `core.hooksPath` set. The diff touches one JSON manifest, one test, one doc page; zero scored functions, so `hook-precommit` has nothing to judge.
- [ ] `python -m crapkit verify` not run locally; nothing in `src/` changed.
- [x] `python -m pytest -q tests/unit/test_plugin_manifest.py` green, 22 passed. CI runs the full matrix.
- [x] Docs updated (`docs/agent-json.md` sample matches the manifest).

## Worth a second look

The manifest keeps no `--repo` argument, matching the current file; the MCP tools take a per-call `repo` argument anyway. If the plugin should pin a default repo, that is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
