### PR TITLE
analyze: the twin-key note is printed by the parent, never by a pool worker (#31)

### DIFF
--- a/src/crapkit/analyze.py
+++ b/src/crapkit/analyze.py
@@ -188,6 +188,9 @@ def _note_twin_keys(rel_path: str, records: list[FunctionRecord]) -> None:
     otherwise unexplained. C makes the shape ordinary — both arms of an `#ifdef`
     fork are textually present — and so does Python, whose method long_names
     carry no class.
+
+    Printed by the parent process only. A pool worker's stderr is its own,
+    unreconfigured stream (#31), so workers return records and stay silent.
     """
     names = _colliding_names(records)
     if not names:
@@ -204,9 +207,9 @@ def _listed(names: list[str]) -> str:
 
 
 def _file_records(rel_path: str, functions) -> list[FunctionRecord]:
-    records = [_record(rel_path, fn) for fn in functions]
-    _note_twin_keys(rel_path, records)
-    return records
+    """Pure, and silent: this runs inside pool workers, whose stderr is not the
+    parent's. The twin-key note is the caller's to print."""
+    return [_record(rel_path, fn) for fn in functions]
 
 
 # --- how a source file's bytes become text -------------------------------------
@@ -310,9 +313,11 @@ def analyze_source(rel_path: str, code: str) -> list[FunctionRecord]:
     try:
         analyzer = lizard.FileAnalyzer(_extensions_for(rel_path))
         analysis = analyzer.analyze_source_code(rel_path, code)
-        return _file_records(rel_path, analysis.function_list)
+        records = _file_records(rel_path, analysis.function_list)
     except Exception as exc:  # loud, with the file named
         raise ToolError(f"lizard failed on {rel_path}: {exc}") from exc
+    _note_twin_keys(rel_path, records)
+    return records
 
 
 def content_hash(path: Path) -> str:
@@ -545,10 +550,15 @@ def analyze_jobs(
         with ProcessPoolExecutor(max_workers=_memory_bounded(workers)) as pool:
             for rel_path, records in pool.map(analyze_one, jobs, chunksize=chunksize):
                 fresh[rel_path] = records
-        return fresh
-    for job in jobs:
-        rel_path, records = analyze_one(job)
-        fresh[rel_path] = records
+    else:
+        for job in jobs:
+            rel_path, records = analyze_one(job)
+            fresh[rel_path] = records
+    # The parent says things; a worker only measures. A spawned child's stderr
+    # never saw `_reconfigure_streams`, so a note printed from analyze_one
+    # reached a UTF-8 reader in the legacy codepage on Windows (#31).
+    for rel_path, records in fresh.items():
+        _note_twin_keys(rel_path, records)
     return fresh
 
 

--- a/tests/e2e/test_cpp_family_admission_e2e.py
+++ b/tests/e2e/test_cpp_family_admission_e2e.py
@@ -223,10 +223,11 @@ def test_every_pool_worker_applied_the_rvalue_rule(family_repo: Path):
     assert take == {TAKE[2]}, "an rvalue-reference parameter is not a condition"
 
 
-def test_a_pool_worker_reports_the_platform_fork(family_repo: Path):
-    """The line is printed where the analysis happens, which for a repo this
-    size is a spawned child. A line written only on the parent's path would pass
-    every unit test and never fire on a real run."""
+def test_a_pooled_run_reports_the_platform_fork(family_repo: Path):
+    """A repo this size is analysed by spawned workers, and the note is printed
+    by the parent once their records are back (#31). This is the guard that the
+    real pooled path still carries it to stderr; the unit test only proves that
+    a worker's own path stays silent."""
     err = inventory(family_repo)["stderr"]
 
     assert PLAT_OPEN in err

--- a/tests/unit/test_twin_note_parent.py
+++ b/tests/unit/test_twin_note_parent.py
@@ -1,0 +1,66 @@
+"""The twin-key note is printed by the parent process, never by an analysis worker.
+
+`_reconfigure_streams` makes the CLI's pipes UTF-8 on Windows, where a pipe
+otherwise gets the legacy codepage. A `ProcessPoolExecutor` child builds its own
+`sys.stderr` over the inherited handle and never sees that reconfigure, so a
+note printed from `analyze_one` reached a UTF-8 reader as cp1252 bytes (#31: the
+em dash arrived as 0x97 on a stream whose other lines were UTF-8). Workers
+return records; the parent is the only process that says anything.
+"""
+import crapkit.analyze as analyze_module
+from crapkit.analyze import analyze_jobs, analyze_one, analyze_source
+
+TWINS = "def f():\n    return 1\n\n\ndef f():\n    return 2\n"
+
+
+def _twins_job(tmp_path) -> tuple[str, str]:
+    src = tmp_path / "twins.py"
+    src.write_text(TWINS, encoding="utf-8")
+    return str(src), "twins.py"
+
+
+def test_a_worker_returns_records_and_prints_nothing(tmp_path, capsys):
+    rel_path, records = analyze_one(_twins_job(tmp_path))
+
+    assert (rel_path, len(records)) == ("twins.py", 2)
+    assert capsys.readouterr().err == ""
+
+
+def test_the_parent_prints_the_note_once_per_file_after_collecting(tmp_path, capsys):
+    fresh = analyze_jobs([_twins_job(tmp_path)], pool_threshold=10**6)
+
+    assert len(fresh["twins.py"]) == 2
+    err = capsys.readouterr().err
+    assert err.count("more than once") == 1 and "twins.py" in err, err
+
+
+def test_the_pooled_path_prints_from_the_parent_too(tmp_path, capsys, monkeypatch):
+    """A stand-in pool runs the jobs in-process: the question is which side of
+    the pool prints, not whether a child was spawned."""
+    class InProcessPool:
+        def __init__(self, max_workers=None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def map(self, fn, jobs, chunksize=1):
+            return [fn(job) for job in jobs]
+
+    monkeypatch.setattr(analyze_module, "ProcessPoolExecutor", InProcessPool)
+
+    fresh = analyze_jobs([_twins_job(tmp_path)], pool_threshold=1)
+
+    assert len(fresh["twins.py"]) == 2
+    assert capsys.readouterr().err.count("more than once") == 1
+
+
+def test_analyze_source_keeps_the_note_because_it_runs_in_the_parent(capsys):
+    """The hooks analyze staged blobs and edits through this seam, in-process."""
+    records = analyze_source("twins.py", TWINS)
+
+    assert len(records) == 2
+    assert "more than once" in capsys.readouterr().err


### PR DESCRIPTION
Closes #31.

**Defect.** `cli/parser.py` `_reconfigure_streams` makes the parent's stdout and stderr UTF-8 when piped, but the twin-key note (`crapkit: X defines f( ) more than once; each one takes its own ratchet key — ...`) was printed from `_file_records`, which `analyze_one` runs inside the `ProcessPoolExecutor`. On Windows a spawned child builds its own `sys.stderr` over the inherited handle with the locale codepage, so the note's em dash arrived as byte `0x97` on a stream whose other lines were UTF-8. Measured on 0.4.4 with both streams captured as bytes: stdout 0 non-ASCII, stderr exactly one `0x97`, inside that note. A UTF-8 consumer reads U+FFFD there; a gate script that then printed the text on a cp1252 console raised `UnicodeEncodeError` after the lane and replaced the exit code.

**Fix.** Workers only measure. `_file_records` is pure and silent; `analyze_jobs` prints the note once per file after collecting, on the pooled path and the serial one; `analyze_source` (the in-process seam the hooks use) prints it itself, as before. No wording changed, so nothing pinned in the docs moves.

**Tests.** `tests/unit/test_twin_note_parent.py`: a worker returns records and prints nothing (fails on main), the parent prints once per file on the serial path, and on the pooled path with an in-process stand-in pool; `analyze_source` still prints. `tests/unit/test_duplicate_records.py` unchanged and green. Unit suite green on Windows / CPython 3.12.

**Not done here, on purpose.** The issue's third lever, `PYTHONUTF8=1` for lane subprocesses, would change what a consumer's own test suite sees of its locale; a repo that wants it can set `env` on the lane in `crapkit.toml` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
