### PR TITLE
fix: skip suite comparison without fresh junit counts

### DIFF
--- a/src/crapkit/cli/verifying.py
+++ b/src/crapkit/cli/verifying.py
@@ -481,8 +481,12 @@ def _warn_suite_shrink(baseline: dict, provenance: dict) -> None:
     for name, prov in provenance.items():
         base = baseline.get("lanes", {}).get(name, {})
         b_total, b_skip = base.get("tests_total"), base.get("tests_skipped")
-        if b_total and prov.get("tests_total", 0) < b_total:
-            print(f"warning: lane {name!r} runs {b_total - prov['tests_total']} "
+        fresh_total = prov.get("tests_total")
+        if b_total and fresh_total is None:
+            print(f"warning: lane {name!r} wrote no junit this run; suite-size "
+                  "comparison skipped", file=sys.stderr)
+        elif b_total and fresh_total < b_total:
+            print(f"warning: lane {name!r} runs {b_total - fresh_total} "
                   f"fewer tests than the baseline", file=sys.stderr)
         if b_skip is not None and prov.get("tests_skipped", 0) > b_skip:
             print(f"warning: lane {name!r} skips {prov['tests_skipped'] - b_skip} "

--- a/tests/e2e/test_flake_retry_e2e.py
+++ b/tests/e2e/test_flake_retry_e2e.py
@@ -37,8 +37,11 @@ elif mode == 'shrunk':
     body = SKIPPED
 else:
     body = FAIL + STEADY
-with open('junit.xml', 'w', encoding='utf-8') as fh:
-    fh.write('<testsuite>' + body + '</testsuite>')
+if mode == 'missing':
+    os.remove('junit.xml')
+else:
+    with open('junit.xml', 'w', encoding='utf-8') as fh:
+        fh.write('<testsuite>' + body + '</testsuite>')
 """
 
 TOML = (
@@ -100,3 +103,14 @@ def test_verify_warns_when_the_suite_shrinks_or_skips_more(flaky_repo: Path):
     assert res.returncode == 0, res.stdout + res.stderr
     assert "fewer tests" in res.stderr
     assert "skips" in res.stderr
+
+
+def test_verify_skips_suite_comparison_when_fresh_junit_is_missing(flaky_repo: Path):
+    (flaky_repo / "state.txt").write_text("missing", encoding="utf-8")
+    config = (flaky_repo / "crapkit.toml").read_text(encoding="utf-8")
+    (flaky_repo / "crapkit.toml").write_text(
+        config.replace('results_artifact = "junit.xml"\n', ""), encoding="utf-8"
+    )
+    res = run_cli(flaky_repo, "verify")
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "wrote no junit this run; suite-size comparison skipped" in res.stderr


### PR DESCRIPTION
## Summary

Fixes #30.

`crapkit verify` crashed with `KeyError: 'tests_total'` when the baseline had JUnit suite counts but the fresh lane run produced coverage without a JUnit report. This happened after the verdict was already computable and incorrectly turned a warning condition into a failed command.

## Changes

- Read the fresh `tests_total` value once and distinguish a missing count from zero.
- Skip suite-size comparison when the fresh lane has no JUnit count and emit an explicit warning.
- Add an end-to-end regression covering a baseline with JUnit counts followed by a fresh run without them.

The change is limited to suite-size warning logic; existing comparisons for present counts and skipped-test counts are unchanged.

## Tests

- `uv run python -m pytest tests/e2e/test_flake_retry_e2e.py -q` (5 passed)
- `uv run python -m pytest tests/unit -q` (completed without test failures; existing Windows encoding warning and skips were reported)
- `git diff --check` (passed)

`uv run python -m crapkit coverage` was attempted for the repository self-check but hung without producing a baseline snapshot on this Windows environment and was safely interrupted. Consequently `crapkit verify` could not be run against a generated baseline locally. No Docker or external service is required for this change.

## Compatibility

Fresh lanes without JUnit counts no longer crash verification. They receive an explicit trust-downgrade warning and continue through the normal verdict path.
