### PR TITLE
packet: the commands a packet names are spelled as the console script (#37)

### DIFF
--- a/src/crapkit/packet.py
+++ b/src/crapkit/packet.py
@@ -34,7 +34,14 @@ ANONYMOUS = "(anonymous)"
 # re-reads the snapshot that is already stale. `--reuse-unchanged` reruns only
 # the lanes whose scope files moved and parses the rest off the artifacts they
 # already have, so it is the cheapest call that still writes a run.
-REFRESH = "python -m crapkit coverage --reuse-unchanged"
+#
+# Every command the packet names is spelled as the console script, the
+# resolution the hooks and the plugin manifest already trust (#20, #37). Bare
+# `python` resolves to the WindowsApps stub, to a venv without crapkit, or,
+# for a child of a venv interpreter launched without a shell, to the base
+# interpreter the venv wraps: Windows searches the parent application's
+# directory before PATH, and a venv's python.exe is a trampoline for that base.
+REFRESH = "crapkit coverage --reuse-unchanged"
 
 
 def function_source(text: str | None, start: int, end: int) -> str | None:
@@ -119,9 +126,9 @@ def commands(path: str, scoped: str | None, note: str = "") -> dict:
     nothing on disk and that one does: a read-only session, or one holding a
     tree it is not allowed to score, has to know which of the four it may run.
     """
-    out = {"gate": f"python -m crapkit rescore {path} --gate",
+    out = {"gate": f"crapkit rescore {path} --gate",
            "scoped_tests": scoped,
-           "verify": "python -m crapkit verify",
+           "verify": "crapkit verify",
            "refresh": REFRESH,
            "refresh_writes_run": True}
     if scoped is None and note:

--- a/tests/e2e/test_brief_packet_e2e.py
+++ b/tests/e2e/test_brief_packet_e2e.py
@@ -200,10 +200,10 @@ def test_the_packet_carries_the_commands_to_run_next(repo: Path):
     out = brief(repo, "core/alpha.py", "alpha")
 
     assert out["commands"] == {
-        "gate": "python -m crapkit rescore core/alpha.py --gate",
+        "gate": "crapkit rescore core/alpha.py --gate",
         "scoped_tests": 'python -m pytest "core/alpha.py"',
-        "verify": "python -m crapkit verify",
-        "refresh": "python -m crapkit coverage --reuse-unchanged",
+        "verify": "crapkit verify",
+        "refresh": "crapkit coverage --reuse-unchanged",
         "refresh_writes_run": True,
     }
 

--- a/tests/e2e/test_packet_refresh_e2e.py
+++ b/tests/e2e/test_packet_refresh_e2e.py
@@ -131,7 +131,7 @@ def test_the_packet_says_the_refresh_writes_a_run(repo: Path):
     commands = brief(repo, "core/alpha.py", "alpha")["commands"]
 
     assert commands["refresh_writes_run"] is True
-    assert commands["refresh"].startswith("python -m crapkit coverage")
+    assert commands["refresh"].startswith("crapkit coverage")
 
 
 # --- one budget, both commands ----------------------------------------------

--- a/tests/unit/test_anon_handles.py
+++ b/tests/unit/test_anon_handles.py
@@ -211,5 +211,5 @@ def test_a_row_at_its_ceiling_needs_no_pieces():
 def test_the_refresh_command_writes_a_run_rather_than_rereading_one():
     out = packet.commands("core/alpha.py", 'pytest "core/alpha.py"')
 
-    assert out["refresh"] == "python -m crapkit coverage --reuse-unchanged"
+    assert out["refresh"] == "crapkit coverage --reuse-unchanged"
     assert out["refresh_writes_run"] is True

--- a/tests/unit/test_packet.py
+++ b/tests/unit/test_packet.py
@@ -112,12 +112,12 @@ def test_the_commands_carry_the_path_and_the_function_filled_in():
     out = packet.commands("core/alpha.py", 'pytest "core/alpha.py"')
 
     assert out == {
-        "gate": "python -m crapkit rescore core/alpha.py --gate",
+        "gate": "crapkit rescore core/alpha.py --gate",
         "scoped_tests": 'pytest "core/alpha.py"',
-        "verify": "python -m crapkit verify",
+        "verify": "crapkit verify",
         # a second `brief` re-reads the snapshot that is already stale, so the
         # field that answers `stale: true` has to be the one that writes a run
-        "refresh": "python -m crapkit coverage --reuse-unchanged",
+        "refresh": "crapkit coverage --reuse-unchanged",
         "refresh_writes_run": True,
     }
 


### PR DESCRIPTION
Closes #37.

**Defect.** `docs/agent-json.md:300-304` and AGENTS.md steps 3 and 5 document the packet's commands as `crapkit rescore ... --gate`, `crapkit coverage --reuse-unchanged`, `crapkit verify` ("commands.gate, verbatim"); `packet.py` emitted `python -m crapkit ...` for all three. The one e2e test that executes the printed command (`test_packet_refresh_e2e.py::test_the_refresh_command_clears_the_staleness_it_is_printed_for`) fails on a Windows box that develops in a uv venv: `C:\...\uv\python\cpython-3.12-...\python.exe: No module named crapkit`. Measured from the venv interpreter itself: `shutil.which("python")` is the venv's exe, yet a child `["python", ...]` launched without a shell lands on the base interpreter (Windows searches the parent application's directory before PATH, and a venv's `python.exe` is a trampoline for that base), while `["crapkit", "--version"]` answers `crapkit 0.4.4`. Same family as #20.

**Change.** The three strings in `packet.py` are the console script, matching the docs and the resolution the hooks and the plugin manifest already trust; the comment above `REFRESH` records why. The unit and e2e pins that spelled the old form (`test_anon_handles.py`, `test_packet.py`, `test_brief_packet_e2e.py`) move with it. `test_handle_docs_contract.py` already derived the flag from `REFRESH` past the `crapkit ` prefix and needs nothing. The refresh e2e test keeps executing the command exactly as printed, which is the point of that test; with `pip install -e` and on the CI runner the console script is on PATH.

**Tests.** Unit suite green; `test_packet_refresh_e2e.py` and `test_brief_packet_e2e.py` green on Windows / CPython 3.12 (the refresh test fails on main on this box, passes with this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
