### PR TITLE
0.4.5: name the lane log, refuse an artifact from another tree, pin the lane's python

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,7 @@ This is the slow step and the only authoritative one.
 | Exit | Verdict | Next action |
 |---|---|---|
 | 0 | pass | baseline advanced, ratchet tightened, finished claims released. Commit |
-| 5 | a lane produced no artifact | tooling, not your code: fix the lane command in crapkit.toml |
+| 5 | a lane produced no artifact, or one that measured a different tree | tooling, not your code: read the lane log the message names, then fix the lane command in crapkit.toml |
 | 6 | gate: a touched function is over its ceiling on CRAP | decompose it, or cover it |
 | 7 | ratchet: a recorded score got worse | restore that function below its mark |
 | 8 | a test that passed in the baseline fails now | fix the test or the code |
@@ -239,7 +239,7 @@ findings, or pass `--baseline ID` to accept the newer run deliberately.
 The lines verify prints, one per finding kind, collected here from separate runs:
 
     verify OK @ f6e9bde18a7 vs baseline f6e9bde18a7 (1 changed files)
-    crapkit: lane 'py' FAILED: lane 'py' produced no artifact at .crapkit/cov/py.json (command exit 4)
+    crapkit: lane 'py' FAILED: lane 'py' produced no artifact at .crapkit/cov/py.json (command exit 4); full log: /repo/.crapkit/lane-py.log; last output: ...
     verify FAILED @ 3a45b8a9b6c vs baseline 03d9cac1397 (1 changed files)
       GATE  crap     42.0  ccn   6 cov 0%  calc/report.py:22  bucket( counts , low , high , invert , label )  -> add-tests  [dirty]
       RATCHET  calc/report.py  spread( counts , low , high , invert , label , pad ): 8.0 -> 72.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 0.4.5 — 2026-08-29
+
+Three more field findings from @nicolaschapados, out of one incident on a real
+pytest/uv project checked out twice through git worktrees. The incident itself was
+not a crapkit bug — the shell held checkout B's venv while crapkit ran in checkout
+A, and B's editable install pointed pytest at B's sources. crapkit made it far
+harder to find than it should have been, and one step away from answering it
+wrongly and confidently.
+
+### A failing lane now says where its log is
+`_raise_no_artifact` took the log path and never printed it. All a reporter saw was
+a 500-BYTE tail that began mid-line — `last output:  short test summary info ====`
+— with all ten collection tracebacks cut off above it and nothing naming
+`.crapkit/lane-py.log`; finding the log took a second agent. Every no-artifact
+refusal now carries `full log: <path>` before the tail it quotes. The tail is cut on
+line boundaries, so it can no longer open on a fragment that reads like the start of
+a message. And when the end of the log names no cause — pytest closes on a summary
+block of `ERROR path` lines saying which files broke and never why — the last few
+lines that DO name one are pulled up in front of it, with an ellipsis marking the
+output skipped between them.
+
+### An artifact that measured a different tree is refused, not scored
+Nothing checked that a lane's artifact was about this checkout. Coverage joins on
+path and nothing else, so an artifact whose paths reach none of the scopes its lane
+claims contributes exactly nothing and every function in those scopes reads
+`untested` — a confident `N untested … grade F` assembled out of a tooling mistake,
+which is worse than the exit 5 a missing artifact already earns because it looks
+like an answer. In the incident this failed loudly only because the two checkouts'
+APIs had diverged; had they matched, as two worktrees of one branch normally do, the
+suite would have passed and the grade would have been fiction. Such a lane now fails
+like any other: the message quotes a few of the paths the artifact does name, points
+at `path_prefix` as the legitimate remapping knob, and the scopes fall back to
+`no-lane` rather than `untested`. Zero overlap is the whole test — a partial overlap
+has honest readings and any threshold over zero would need tuning per repo.
+
+### `init` binds the lane to the environment the repo pins
+The scaffolded lane was a bare `python -m pytest`, which resolves through the shell's
+PATH to whichever venv happens to be active — the root cause of the whole report. A
+lockfile beside the pytest marker now names the manager that owns the environment,
+and `init` writes its `run`: `uv.lock` gives `uv run python -m pytest …`, and
+`poetry.lock`, `pdm.lock` and `Pipfile.lock` the same for theirs, first match in that
+order. The `[crapkit.scoped_tests]` entry takes the same prefix, read back off the
+lane so the two cannot drift. A managed lane is not probed for pytest-cov: `uv run`
+and its siblings create or sync the project environment before running anything, and
+`init` has no business provisioning one to ask a question about it.
+
 ## 0.4.4 — 2026-08-29
 
 Three field fixes from @nicolaschapados (PR #23) against a real pytest/uv project,

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ always advances the baseline.
 | 2 | Usage error from argparse: unknown flag, missing positional. Raised before crapkit's own error handling. |
 | 3 | Config error: `crapkit.toml` missing or unparseable, an unknown language or parser, a ratchet metric-stamp mismatch, a `test-scoped` file under no scope or under a scope with no template. |
 | 4 | Git error: not a repository, a baseline commit rewritten out of the history. |
-| 5 | Tool error: lizard not importable, a lane produced no artifact, a lane timed out past its retries, an override alert command failed. |
+| 5 | Tool error: lizard not importable, a lane produced no artifact or one that measured a different tree, a lane timed out past its retries, an override alert command failed. |
 | 6 | Gate violation. A function the diff touched is over its ceiling, or `rescore --gate` found one, or `hook-precommit` did. |
 | 7 | Ratchet regression. A marked function scores worse than its recorded high-water mark, touched or not. |
 | 8 | New test failures against the baseline run. Failures the baseline already had do not count. |
@@ -491,8 +491,12 @@ added to .gitignore: .crapkit/, .coverage, __pycache__/
 `init` sniffs tracked source into one scope per top-level source directory, and detects a
 coverage lane from what the repo already has: a pytest marker file (`pyproject.toml`,
 `pytest.ini`, `setup.cfg`) writes a live `[[lane]]`, and so does a `test` script or
-`vitest`/`jest` in `package.json`. Whatever it detects, it also leaves commented templates
-for the runners it did not find. Every lane it writes reports into `.crapkit/cov/`, which
+`vitest`/`jest` in `package.json`. A lockfile beside them names the environment: `uv.lock`,
+`poetry.lock`, `pdm.lock` or `Pipfile.lock` makes the lane `uv run python -m pytest …` (and
+the matching `run` for the rest), because a bare `python` binds to whichever venv the shell
+has active rather than the one the repo pins — see
+[The interpreter a lane binds to](docs/lanes.md#the-interpreter-a-lane-binds-to). Whatever
+it detects, it also leaves commented templates for the runners it did not find. Every lane it writes reports into `.crapkit/cov/`, which
 is why the `.gitignore` list is so short: see
 [Where artifacts live](docs/lanes.md#where-artifacts-live).
 
@@ -648,7 +652,7 @@ exit 5:
 
 ```
 $ crapkit coverage
-crapkit: lane 'js' FAILED: lane 'js' produced no artifact at .crapkit/cov/js/coverage-final.json (command exit 1); last output: $ npm run test -- --coverage --coverage.reportsDirectory=.crapkit/cov/js
+crapkit: lane 'js' FAILED: lane 'js' produced no artifact at .crapkit/cov/js/coverage-final.json (command exit 1); full log: /repo/.crapkit/lane-js.log; last output: $ npm run test -- --coverage --coverage.reportsDirectory=.crapkit/cov/js
 
  MISSING DEPENDENCY  Cannot find dependency '@vitest/coverage-v8'
 

--- a/docs/handbook.html
+++ b/docs/handbook.html
@@ -492,7 +492,7 @@ retries = 1                 # and how often a flaky lane gets another shot</code
   <tr><td class="mono">2</td><td>Usage error</td><td>argparse refused. Check the flag spelling and order.</td></tr>
   <tr><td class="mono">3</td><td>Config gap</td><td>A scope without a template, a metric-stamp mismatch. Fix <code>crapkit.toml</code> or restamp.</td></tr>
   <tr><td class="mono">4</td><td>Git error</td><td>Not a repository, or a baseline commit rewritten out of history by a force-push.</td></tr>
-  <tr><td class="mono">5</td><td>Tool error: lizard missing, a lane produced no artifact or timed out past retries, an alert command failed</td><td>For the no-artifact case: fix the lane, not the code. Four root causes, triaged in <a href="lanes.md">docs/lanes.md</a>.</td></tr>
+  <tr><td class="mono">5</td><td>Tool error: lizard missing, a lane produced no artifact (or one measuring a different tree) or timed out past retries, an alert command failed</td><td>For the artifact cases: fix the lane, not the code. The refusal names the lane log; root causes are triaged in <a href="lanes.md">docs/lanes.md</a>.</td></tr>
   <tr><td class="mono">6</td><td>Gate: touched function over its ceiling</td><td>Decompose until every piece fits.</td></tr>
   <tr><td class="mono">7</td><td>Ratchet regression</td><td>A standing mark got worse. On a function you never edited, suspect test rot first.</td></tr>
   <tr><td class="mono">8</td><td>New test failures vs baseline</td><td>The flake retest already ran if configured. What remains is real.</td></tr>

--- a/docs/lanes.md
+++ b/docs/lanes.md
@@ -97,7 +97,7 @@ vitest ships **no coverage provider**. Without one, `crapkit init` writes a lane
 reports no problems, and `coverage` exits 5:
 
 ```
-crapkit: lane 'js' FAILED: lane 'js' produced no artifact at .crapkit/cov/js/coverage-final.json (command exit 1); last output: $ npm run test -- --coverage --coverage.reportsDirectory=.crapkit/cov/js
+crapkit: lane 'js' FAILED: lane 'js' produced no artifact at .crapkit/cov/js/coverage-final.json (command exit 1); full log: /repo/.crapkit/lane-js.log; last output: $ npm run test -- --coverage --coverage.reportsDirectory=.crapkit/cov/js
  MISSING DEPENDENCY  Cannot find dependency '@vitest/coverage-v8'
 ```
 
@@ -254,6 +254,45 @@ crapkit: every lane failed: ...
 ```
 
 Exit 5.
+
+### The interpreter a lane binds to
+
+`python -m pytest` is not one command. `python` resolves through the shell's `PATH`, so
+the lane runs under whichever virtualenv the shell happened to have active — which is
+almost always right, and silently wrong in the one case that matters.
+
+Two git worktrees of one repo. Checkout B's venv is active, and it holds an editable
+install pointing at B's `src`. Run `crapkit coverage` in checkout A and the lane's pytest
+imports **B's** sources. When the two checkouts' APIs have diverged, collection dies and
+you get exit 5. When they have not — the ordinary case for two worktrees of one branch —
+the suite passes, coverage.py measures B's files, the join against A's scoped files finds
+nothing, and crapkit prints a confident `N untested … grade F` that is entirely an
+artifact of the wrong venv.
+
+A lockfile is the repo saying which environment is the right one, and the manager's `run`
+is the only spelling that binds a command to it. `crapkit init` reads that off the tree
+along with everything else:
+
+| Lockfile at the root | Lane command |
+|---|---|
+| `uv.lock` | `uv run python -m pytest …` |
+| `poetry.lock` | `poetry run python -m pytest …` |
+| `pdm.lock` | `pdm run python -m pytest …` |
+| `Pipfile.lock` | `pipenv run python -m pytest …` |
+| none | `python -m pytest …` (or `python3`, whichever resolves) |
+
+The first match in that order wins, so a repo mid-migration between two managers gets the
+same config every time. The `[crapkit.scoped_tests]` entry `init` writes takes the same
+prefix: step 3 measuring one environment while step 4 tests another is the same bug one
+command later.
+
+`init` does not probe a managed lane for `pytest-cov`. `uv run` and its siblings create or
+sync the project environment before running anything, and `init` has no business
+provisioning one to ask a question about it. If the plugin is missing, the lane says so on
+its first run — with the log path.
+
+Writing the prefix by hand is the fix for a repo that adopted crapkit earlier, or one that
+pins its environment some other way: `command` is a shell string and takes anything.
 
 Prefer `--cov=<module>` over `--cov=<path>` when your suite spawns subprocesses. pytest-cov
 hands children a `COV_CORE_SOURCE` that must resolve from the **child's** cwd, so a
@@ -559,7 +598,7 @@ A lane failure is recorded, not fatal. The run still happens:
 
 ```
 $ crapkit coverage
-crapkit: lane 'scripts' FAILED: lane 'scripts' produced no artifact at .crapkit/cov/scripts.json (command exit 1)
+crapkit: lane 'scripts' FAILED: lane 'scripts' produced no artifact at .crapkit/cov/scripts.json (command exit 1); full log: /repo/.crapkit/lane-scripts.log
 run 3 @ 393b8dad2a1: 2 functions scored — 1 measured / 0 untested / 1 no-lane / 0 cc-only, 2 over target 6, CRAP load 56.83, grade F
 ```
 
@@ -577,3 +616,48 @@ Exit 5. Four consequences:
 
 `coverage --json` carries the reasons under `lane_failures`, keyed by lane name, alongside
 the successful lanes' provenance under `lanes`.
+
+### The failure message names its own log
+
+Every lane refusal carries `full log: <path>` before the tail it quotes. The tail is 500
+characters cut on line boundaries; the log is the whole run. When the end of the log is a
+summary block — pytest closes on `ERROR path` lines that say which files broke and never
+why — the message pulls the last few lines that DO name a cause up in front of it, with an
+ellipsis marking the output skipped between them:
+
+```
+crapkit: lane 'py' FAILED: lane 'py' produced no artifact at .crapkit/cov/py.json (command exit 2); full log: /repo/.crapkit/lane-py.log; last output: E   ImportError: cannot import name 'Widget' from 'faro.core' (/other/checkout/src/faro/core.py)
+...
+ERROR tests/test_widgets.py
+============================== 10 errors in 0.62s ==============================
+(exit 2)
+```
+
+---
+
+## An artifact that measured a different tree
+
+A lane whose artifact names paths that reach **none** of the scopes it claims is refused:
+
+```
+$ crapkit coverage
+crapkit: lane 'py' FAILED: lane 'py' measured 412 file(s), none of them under the paths its scopes declare (src/) — .crapkit/cov/py.json does not describe this checkout, and joining it would score every function in those scopes untested; it reports paths like /other/checkout/src/faro/core.py. Set path_prefix on the lane when the runner reports paths relative to a subdirectory; otherwise the run measured a different tree (a stale artifact, or a suite importing another checkout through the venv the shell had active)
+```
+
+Coverage joins on path and nothing else, so such an artifact contributes exactly nothing
+and every function in those scopes reads `untested`. That is a grade assembled out of a
+tooling mistake, and it is worse than the exit 5 a missing artifact already earns, because
+it looks like an answer. The refusal is an ordinary lane failure: the scopes fall back to
+`no-lane`, and the four consequences above apply unchanged.
+
+Zero overlap is the whole test. A partial overlap has honest readings — a lane measuring
+part of a scope, generated files outside it — and any threshold over zero would need
+tuning per repo; zero has one cause and no reading under which the join was going to work.
+
+Two things reach it:
+
+- **The runner reports paths relative to a subdirectory.** [`path_prefix`](#running-from-a-subdirectory)
+  is the knob, and it is applied before this check, so a prefix that fixes the join is
+  never refused here.
+- **The run measured another tree.** A stale artifact copied in, or the wrong environment:
+  see [The interpreter a lane binds to](#the-interpreter-a-lane-binds-to).

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crapkit",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "crapkit's agent surface: three skills, the read-side MCP server, and one advisory PostToolUse hook that names functions an edit pushed over their ceiling. Needs the crapkit CLI on PATH, crapkit 0.4.0 or newer, which is the release that answers `crapkit claude-hook`. The commit gate stays the only enforcement point; this hook never blocks.",
   "author": {
     "name": "Jean-Francois Gagne"

--- a/plugin/skills/crapkit-recover/SKILL.md
+++ b/plugin/skills/crapkit-recover/SKILL.md
@@ -35,7 +35,7 @@ in this version.
 |---|---|---|---|
 | 3 | config: `crapkit.toml` unparseable, a metric-stamp mismatch, a `test-scoped` file under no templated scope | [docs: configuration](https://github.com/JeanFrancoisGagne/crapkit/blob/main/docs/configuration.md) | `crapkit doctor` |
 | 4 | git: not a repository, or a baseline commit rewritten out of the history | [README: exit codes](https://github.com/JeanFrancoisGagne/crapkit/blob/main/README.md#exit-codes) | `crapkit runs list` |
-| 5 | a lane produced no artifact, timed out past its retries, or refused a container | [docs: what a failed lane does to scoring](https://github.com/JeanFrancoisGagne/crapkit/blob/main/docs/lanes.md#what-a-failed-lane-does-to-scoring) | `crapkit coverage --lane NAME` |
+| 5 | a lane produced no artifact, produced one measuring a different tree, timed out past its retries, or refused a container | [docs: what a failed lane does to scoring](https://github.com/JeanFrancoisGagne/crapkit/blob/main/docs/lanes.md#what-a-failed-lane-does-to-scoring) | `crapkit coverage --lane NAME` |
 | 6 | gate: a function the diff touched is over its ceiling and carries no ratchet mark | [AGENTS: gate the edit](https://github.com/JeanFrancoisGagne/crapkit/blob/main/AGENTS.md#3-gate-the-edit) | `crapkit rescore FILE --gate` |
 | 7 | ratchet: a marked function scores worse than its recorded mark | [docs: how verify uses the ratchet](https://github.com/JeanFrancoisGagne/crapkit/blob/main/docs/ratchet.md#how-verify-uses-the-ratchet) | `crapkit explain PATH NAME` |
 | 8 | a test that passed in the baseline fails now | [README: exit codes](https://github.com/JeanFrancoisGagne/crapkit/blob/main/README.md#exit-codes) | `crapkit test-scoped FILE` |
@@ -48,8 +48,9 @@ splits them by command.
 
 ## "produced no artifact": four causes
 
-The lane log names which one. It sits at `.crapkit/lane-<name>.log`, and the failure line
-quotes its tail.
+The lane log names which one. It sits at `.crapkit/lane-<name>.log`; the failure line quotes
+its tail and names that path in full, so read the log before guessing — the tail is 500
+characters of a file that holds the whole run.
 
 | Cause | Signature in the log | Owner |
 |---|---|---|
@@ -60,6 +61,21 @@ quotes its tail.
 
 This is tooling, not your code. The run still happened: the failed lane's scopes fall back to
 `no-lane`, the run is typed `partial`, and `verify` refuses to conclude at all.
+
+## "measured N file(s), none of them under the paths its scopes declare"
+
+A different exit-5 refusal, and the one that would otherwise have been an answer. The lane
+wrote a real artifact, and none of the paths in it reach the scopes the lane claims — so
+the join finds nothing and every function in those scopes would score `untested`.
+
+Two causes, and the message quotes a few of the measured paths so you can tell them apart:
+
+| The paths it reports | Cause | Fix |
+|---|---|---|
+| repo-relative but rooted one level down (`faro/core.py` where the scope is `src`) | the runner reports relative to a subdirectory | set `path_prefix` on the lane |
+| absolute, or under some other checkout | the run measured a different tree | a stale artifact, or the wrong environment: a `python -m pytest` lane binds to whatever venv the shell has active, which in a second worktree is the other checkout's. Run the suite through the project's own manager (`uv run python -m pytest …`) |
+
+Owner: [docs: an artifact that measured a different tree](https://github.com/JeanFrancoisGagne/crapkit/blob/main/docs/lanes.md#an-artifact-that-measured-a-different-tree).
 
 ## Exit 7 on a function you never touched
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crapkit"
-version = "0.4.4"
+version = "0.4.5"
 description = "Scores every function on complexity times uncovered risk, ranks the worst, and blocks commits that add more."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }

--- a/src/crapkit/__init__.py
+++ b/src/crapkit/__init__.py
@@ -1,2 +1,2 @@
 """crapkit: deterministic CRAP-score framework."""
-__version__ = "0.4.4"
+__version__ = "0.4.5"

--- a/src/crapkit/cli/__init__.py
+++ b/src/crapkit/cli/__init__.py
@@ -177,6 +177,7 @@ _OWNER = {
     "_pick_function": "queue",
     "_plugin_json": "admin",
     "_policy_findings": "ratchet_cmds",
+    "_present_lockfiles": "admin",
     "_present_markers": "admin",
     "_present_on_disk": "scoring",
     "_prior_crap": "verifying",

--- a/src/crapkit/cli/admin.py
+++ b/src/crapkit/cli/admin.py
@@ -21,11 +21,29 @@ from ..universe import assign_files, scan_files
 from ._shared import _file_sizer, _load_repo_config, _print_json
 
 
-def _interpreter() -> str:
-    """The interpreter name a committed config can call. sys.executable is this
-    machine's absolute path and would not survive the repo reaching anyone else."""
+def _present_lockfiles(root: Path) -> frozenset[str]:
+    from ..scaffold import LOCKFILE_RUNNERS
+
+    return frozenset(name for name, _ in LOCKFILE_RUNNERS if (root / name).is_file())
+
+
+def _interpreter(root: Path) -> str:
+    """The python invocation a committed config can call.
+
+    A lockfile at the root wins: `uv run python` and its siblings resolve to the
+    environment the repo pins, while a bare `python` resolves to whichever venv
+    the shell happens to have active — which in two worktrees of one branch is
+    how a lane measures the OTHER checkout and scores this one untested. Names
+    only, never sys.executable: that is this machine's absolute path and would
+    not survive the repo reaching anyone else.
+    """
     import shutil
 
+    from ..scaffold import lockfile_runner
+
+    runner = lockfile_runner(_present_lockfiles(root))
+    if runner:
+        return f"{runner} python"  # the manager's environment always spells it `python`
     return "python" if shutil.which("python") else "python3"
 
 
@@ -88,12 +106,22 @@ def _pytest_cov_probe(command: str) -> bool:
     through the same shell as the lane, so a bare `python` resolves to the one
     the lane will get (a .bat shim included), not the one CreateProcess finds.
     True too when the probe cannot run — only a clean "no" earns the warning,
-    and a missing interpreter is doctor's finding, not this one's."""
+    and a missing interpreter is doctor's finding, not this one's.
+
+    A lane headed by an environment manager is left alone. `uv run` and its
+    siblings CREATE or sync the project environment before running anything, and
+    `init` has no business provisioning one to ask a question about it — the
+    answer would describe an environment init had just built. Probing the head
+    word instead (`uv -c "import pytest_cov"`) is not the python the lane runs
+    and would warn about the wrong gap on every uv repo.
+    """
     import shutil
     import subprocess
 
+    from ..scaffold import ENV_MANAGERS
+
     words = shell_words(command)
-    if not words or shutil.which(words[0]) is None:
+    if not words or words[0] in ENV_MANAGERS or shutil.which(words[0]) is None:
         return True
     probe = f'{_shell_quote(words[0])} -c "import pytest_cov"'
     try:
@@ -156,7 +184,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     # A config whose lanes are all commented out scores every function no-lane,
     # so a fresh repo cannot rank anything until somebody hand-writes a lane.
     lanes = detect_lanes(_present_markers(root), _package_json(root),
-                         interpreter=_interpreter())
+                         interpreter=_interpreter(root))
     text = starter_toml(scopes, lanes)
     load_config_text(text)  # self-check: never write a config crapkit cannot read back
     toml_path.write_text(text, encoding="utf-8", newline="\n")

--- a/src/crapkit/lanes.py
+++ b/src/crapkit/lanes.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -24,6 +25,7 @@ from .coverage_istanbul import FnCoverage
 from .covstream import parse_coveragepy_file, parse_istanbul_file
 from .errors import GitError, ToolError
 from .gitio import GitFacts
+from .universe import in_scope_reach, scope_reach
 
 
 def _in_container() -> bool:
@@ -43,10 +45,62 @@ def _lane_log_path(root: Path, lane: Lane) -> Path:
     return log_path
 
 
-def _log_tail(log_path: Path) -> str:
+_TAIL_BUDGET = 500
+_CAUSE_LINES = 3
+_CAUSE_WIDTH = 200
+
+# Lines that name a cause rather than restate a count: pytest's `E   ` gutter, a
+# traceback header, a bare exception line. A run that died in collection ends
+# with a summary block of `ERROR path` lines saying WHICH files broke and never
+# why, so a plain tail spends its whole budget on filenames while the reason
+# scrolls off above it.
+_DIAGNOSTIC = re.compile(r"\s*(E\s|Traceback \(most recent call last\)|\w*(Error|Exception): )")
+
+
+def _log_lines(log_path: Path) -> list[str]:
     if not log_path.is_file():
-        return ""
-    return log_path.read_text(encoding="utf-8", errors="replace").strip()[-500:]
+        return []
+    return log_path.read_text(encoding="utf-8", errors="replace").strip().splitlines()
+
+
+def _tail_lines(lines: list[str], budget: int) -> list[str]:
+    """The last WHOLE lines that fit the budget. A tail cut on a byte count
+    starts mid-line, and the reader cannot tell that fragment from the real
+    start of the message: the report that prompted this opened on
+    "short test summary info ====" and read as the first thing the run said.
+    One line over budget on its own keeps its end behind an ellipsis, which at
+    least says so."""
+    kept: list[str] = []
+    left = budget
+    for line in reversed(lines):
+        left -= len(line) + 1
+        if left < 0:
+            break
+        kept.append(line)
+    if kept:
+        kept.reverse()
+        return kept
+    return ["..." + lines[-1][-budget:]] if lines else []
+
+
+def _cause_lines(lines: list[str], tail: list[str]) -> list[str]:
+    """The last lines anywhere in the log that name a failure, when the tail
+    carries none. Nothing when the tail already says why — repeating it would
+    spend the message on the same words twice."""
+    if any(_DIAGNOSTIC.match(line) for line in tail):
+        return []
+    named = [line.strip()[:_CAUSE_WIDTH] for line in lines if _DIAGNOSTIC.match(line)]
+    return named[-_CAUSE_LINES:]
+
+
+def _log_tail(log_path: Path) -> str:
+    """What the log says about its own failure: the reason lines first when the
+    end of the log does not carry one, then the last whole lines of output. The
+    ellipsis between them marks the output they skipped over."""
+    lines = _log_lines(log_path)
+    tail = _tail_lines(lines, _TAIL_BUDGET)
+    cause = _cause_lines(lines, tail)
+    return "\n".join([*cause, "...", *tail] if cause else tail)
 
 
 def _popen_kwargs(root: Path, lane: Lane) -> dict:
@@ -97,11 +151,15 @@ def _missing_plugin_hint(tail: str) -> str:
 
 
 def _raise_no_artifact(lane: Lane, log_path: Path, exit_code: int | None) -> None:
+    """The log PATH before the log's words. A tail is 500 characters of a file
+    that holds the whole story, and a reader who is not told where that file is
+    has to go looking for it — one reporter had to ask another agent to find
+    .crapkit/lane-py.log while ten collection tracebacks sat inside it."""
     detail = f" (command exit {exit_code})" if exit_code is not None else ""
     tail = _log_tail(log_path)
     hint = f"; last output: {tail}" if tail else ""
-    raise ToolError(f"lane {lane.name!r} produced no artifact at {lane.artifact}{detail}{hint}"
-                    f"{_missing_plugin_hint(tail)}")
+    raise ToolError(f"lane {lane.name!r} produced no artifact at {lane.artifact}{detail}"
+                    f"; full log: {log_path}{hint}{_missing_plugin_hint(tail)}")
 
 
 def _run_attempts(root: Path, lane: Lane) -> int | None:
@@ -270,6 +328,81 @@ def _read_and_parse(lane: Lane, root: Path,
     raise ToolError(f"lane {lane.name!r}: parser {lane.parser!r} not implemented yet")
 
 
+_SAMPLE_PATHS = 3
+
+# A path the runner could not write relative to this checkout: absolute, drive
+# lettered, or climbing out of the tree. Both parsers rebase a file INSIDE the
+# repo to a repo-relative path, so one that is not is a file somewhere else.
+_DRIVE = re.compile(r"[A-Za-z]:[\\/]")
+
+
+def _escapes_repo(path: str) -> bool:
+    return path.startswith(("/", "../")) or _DRIVE.match(path) is not None
+
+
+def _lane_reach(lane: Lane, scope_paths: dict) -> tuple[frozenset[str], tuple[str, ...]]:
+    """Everything the scopes this lane names can claim, as universe reads it."""
+    return scope_reach(p for name in lane.scopes for p in scope_paths.get(name, ()))
+
+
+def _unreached_prefixes(lane: Lane, coverage: dict, scope_paths: dict) -> tuple[str, ...]:
+    """The prefixes this lane's scopes declare when NOTHING the artifact
+    measured reaches any of them, else (). Empty too when the lane's scopes
+    declare no path at all: nothing to compare against is not evidence."""
+    reach = _lane_reach(lane, scope_paths)
+    if not reach[0] or any(in_scope_reach(reach, path) for path in coverage):
+        return ()
+    return reach[1]
+
+
+def _sample(paths) -> str:
+    return ", ".join(sorted(paths)[:_SAMPLE_PATHS])
+
+
+def _wrong_tree_message(lane: Lane, coverage: dict, prefixes, outside: list[str]) -> str:
+    return (f"lane {lane.name!r} measured {len(coverage)} file(s), none of them under the "
+            f"paths its scopes declare ({', '.join(prefixes)}), and {len(outside)} of them "
+            f"outside this checkout entirely — {lane.artifact} describes a different tree, "
+            f"so joining it would score every function in those scopes untested; it reports "
+            f"paths like {_sample(outside)}. Point the lane at this checkout's own "
+            f"environment (a bare `python -m pytest` binds to whichever venv the shell has "
+            f"active — run it through the project's manager, `uv run python -m pytest ...`), "
+            f"or set path_prefix when the runner reports paths relative to a subdirectory")
+
+
+def _unmeasured_message(lane: Lane, coverage: dict, prefixes) -> str:
+    reports = f"; it measured {_sample(coverage)}" if coverage else ""
+    return (f"lane {lane.name!r} measured {len(coverage)} file(s), none of them under the "
+            f"paths its scopes declare ({', '.join(prefixes)}), so every function in those "
+            f"scopes will score untested{reports} — either nothing in them is exercised yet, "
+            f"or the runner reports paths this lane needs path_prefix to rebase")
+
+
+def _judge_artifact_scope(lane: Lane, coverage: dict, scope_paths: dict | None) -> None:
+    """Say something when a lane's artifact reaches none of the scopes it claims.
+
+    Coverage joins on path and nothing else, so such an artifact contributes
+    exactly nothing and every function in those scopes reads `untested` — a
+    confident "N untested, grade F" assembled out of a tooling mistake, which
+    is worse than the exit 5 a missing artifact earns because it looks like an
+    answer. Two worktrees of one branch reach it quietly: a venv whose editable
+    install points at the other checkout makes coverage.py measure that tree.
+
+    Two verdicts, because zero overlap has two readings and the paths tell them
+    apart. Measured files OUTSIDE this checkout can only be another tree, and
+    that fails the lane. In-tree paths that simply miss the scopes are the
+    greenfield shape as well — a suite that imports none of the scoped source
+    yet, which SHOULD score untested — so that one warns and scores on.
+    """
+    prefixes = _unreached_prefixes(lane, coverage, scope_paths or {})
+    if not prefixes:
+        return
+    outside = sorted(path for path in coverage if _escapes_repo(path))
+    if outside:
+        raise ToolError(_wrong_tree_message(lane, coverage, prefixes, outside))
+    print(f"crapkit: {_unmeasured_message(lane, coverage, prefixes)}", file=sys.stderr)
+
+
 def _results_provenance(root: Path, lane: Lane) -> dict:
     from .junitparse import suite_summary
 
@@ -391,6 +524,7 @@ def run_lane(root: Path, lane: Lane, *, reuse_artifact: bool = False,
     _refuse_container_python(lane)
     exit_code, seconds = _run_or_reuse(root, lane, facts, scope_paths, reuse_artifact)
     coverage, digest = _read_and_parse(lane, root, _artifact_path(root, lane))
+    _judge_artifact_scope(lane, coverage, scope_paths)
     provenance = {
         "artifact_sha256": digest,
         "exit_code": exit_code,

--- a/src/crapkit/scaffold.py
+++ b/src/crapkit/scaffold.py
@@ -95,6 +95,33 @@ class LaneSpec(NamedTuple):
 
 PYTEST_MARKERS = ("pyproject.toml", "pytest.ini", "setup.cfg")
 
+# A lockfile is the repo saying it pins its own environment through a manager,
+# and only that manager's `run` binds a command to it. A bare `python` binds to
+# whatever venv the shell has active instead: the report this came from ran a
+# scaffolded lane in one worktree while the shell held another worktree's venv,
+# whose editable install pointed at the other checkout's sources, and pytest
+# collected ten ImportErrors. Detection is the same file-presence signal that
+# picks the lane itself, so nothing is executed to learn this.
+#
+# First match wins, so a repo carrying two lockfiles resolves the same way every
+# time rather than by dict order.
+LOCKFILE_RUNNERS = (("uv.lock", "uv run"), ("poetry.lock", "poetry run"),
+                    ("pdm.lock", "pdm run"), ("Pipfile.lock", "pipenv run"))
+
+# The word each runner heads its command with, for readers asking "does this
+# lane command go through a manager?"
+ENV_MANAGERS = frozenset(runner.split()[0] for _, runner in LOCKFILE_RUNNERS)
+
+
+def lockfile_runner(present: frozenset[str]) -> str:
+    """The manager prefix that pins a python invocation to THIS project's
+    environment, or "" when no lockfile in the repo names one."""
+    for name, runner in LOCKFILE_RUNNERS:
+        if name in present:
+            return runner
+    return ""
+
+
 _PY_LANGUAGES = ("python",)
 _JS_LANGUAGES = ("javascript", "tsx", "typescript")
 _JS_RUNNER_COMMAND = {"jest": "npx jest --coverage", "vitest": "npx vitest run --coverage"}
@@ -250,18 +277,34 @@ _TEMPLATES = {
 # is the runner that scope's language usually uses, and the whole block stays
 # commented because only the repo knows whether that command is the right one.
 _SCOPED_TEST_COMMANDS = {
-    "python": "python -m pytest {files} -q -p no:cacheprovider",
+    "python": "{python} -m pytest {files} -q -p no:cacheprovider",
     "javascript": "npx vitest run {files}",
     "tsx": "npx vitest run {files}",
     "typescript": "npx vitest run {files}",
 }
 _SCOPED_TEST_PLACEHOLDER = "<your test command> {files}"
+_DEFAULT_PYTHON = "python"
 
 
-def _scoped_test_command(languages: tuple[str, ...]) -> str:
+def python_launcher(lanes: tuple[LaneSpec, ...]) -> str:
+    """The python invocation the detected pytest lane already settled on.
+
+    Read back off the lane rather than passed in beside it, so the scoped-tests
+    entry runs the suite the way the coverage lane runs it and the two cannot
+    drift: a `uv run python` lane with a bare `python` step 4 would measure one
+    environment and test another.
+    """
+    for lane in lanes:
+        head, sep, _ = lane.command.partition(" -m pytest")
+        if sep:
+            return head
+    return _DEFAULT_PYTHON
+
+
+def _scoped_test_command(languages: tuple[str, ...], launcher: str) -> str:
     for language in languages:
         if language in _SCOPED_TEST_COMMANDS:
-            return _SCOPED_TEST_COMMANDS[language]
+            return _SCOPED_TEST_COMMANDS[language].replace("{python}", launcher)
     return _SCOPED_TEST_PLACEHOLDER
 
 
@@ -279,14 +322,16 @@ def _confirmed_languages(lanes: tuple[LaneSpec, ...]) -> frozenset[str]:
     return frozenset({"python"} if any(" -m pytest " in ln.command for ln in lanes) else ())
 
 
-def _scoped_entry_lines(scopes: dict[str, tuple[str, ...]], live: bool) -> list[str]:
+def _scoped_entry_lines(scopes: dict[str, tuple[str, ...]], live: bool,
+                        launcher: str) -> list[str]:
     prefix = "" if live else "# "
-    return [f'{prefix}{name} = "{_scoped_test_command(languages)}"'
+    return [f'{prefix}{name} = "{_scoped_test_command(languages, launcher)}"'
             for name, languages in scopes.items()]
 
 
 def _scoped_tests_stub(scopes: dict[str, tuple[str, ...]],
-                       confirmed: frozenset[str] = frozenset()) -> list[str]:
+                       confirmed: frozenset[str] = frozenset(),
+                       launcher: str = _DEFAULT_PYTHON) -> list[str]:
     """The [crapkit.scoped_tests] block: live entries for scopes whose runner a
     detected lane proves, commented templates for the rest.
 
@@ -299,20 +344,22 @@ def _scoped_tests_stub(scopes: dict[str, tuple[str, ...]],
     rest = {n: l for n, l in scopes.items() if n not in live}
     intro = ["# `crapkit test-scoped FILES` runs one command per scope, with {files}",
              "# replaced by that scope's files, each quoted."]
-    return intro + _live_block(live) + _commented_block(rest, bool(live)) + [""]
+    return (intro + _live_block(live, launcher)
+            + _commented_block(rest, bool(live), launcher) + [""])
 
 
-def _live_block(live: dict[str, tuple[str, ...]]) -> list[str]:
+def _live_block(live: dict[str, tuple[str, ...]], launcher: str) -> list[str]:
     if not live:
         return []
-    return ["[crapkit.scoped_tests]"] + _scoped_entry_lines(live, True)
+    return ["[crapkit.scoped_tests]"] + _scoped_entry_lines(live, True, launcher)
 
 
-def _commented_block(rest: dict[str, tuple[str, ...]], has_live: bool) -> list[str]:
+def _commented_block(rest: dict[str, tuple[str, ...]], has_live: bool,
+                     launcher: str) -> list[str]:
     if not rest:
         return []
     header = ["# Uncomment what fits:"] + ([] if has_live else ["# [crapkit.scoped_tests]"])
-    return header + _scoped_entry_lines(rest, False)
+    return header + _scoped_entry_lines(rest, False, launcher)
 
 
 def _template_lines(covered: set[str], scopes: dict[str, tuple[str, ...]]) -> list[str]:
@@ -342,7 +389,8 @@ def starter_toml(scopes: dict[str, tuple[str, ...]], lanes: tuple[LaneSpec, ...]
     lines += _exclude_stanza()
     live, covered = _live_lanes(lanes, scopes)
     return "\n".join(lines + live + _template_lines(covered, scopes)
-                     + _scoped_tests_stub(scopes, _confirmed_languages(lanes)))
+                     + _scoped_tests_stub(scopes, _confirmed_languages(lanes),
+                                          python_launcher(lanes)))
 
 
 _STORE_IGNORE = ".crapkit/"

--- a/src/crapkit/universe.py
+++ b/src/crapkit/universe.py
@@ -71,11 +71,29 @@ class _ScopeMatch(NamedTuple):
     extensions: tuple[str, ...]
 
 
+def scope_reach(paths) -> tuple[frozenset[str], tuple[str, ...]]:
+    """(exact paths, directory prefixes) for a scope's declared paths: the PATH
+    half of the rule `_owning_scope` assigns files by, with the language test
+    left out.
+
+    Public because a caller outside this module asks the same question from the
+    other end — the lane runner checks whether an artifact's measured paths
+    could be claimed by any scope its lane names — and a second hand-rolled
+    prefix test would drift. Exact paths matter: a scope may declare individual
+    files, and prefixes alone call every one of them unreachable.
+    """
+    declared = tuple(paths)
+    return frozenset(declared), tuple(p.rstrip("/") + "/" for p in declared)
+
+
+def in_scope_reach(reach: tuple[frozenset[str], tuple[str, ...]], path: str) -> bool:
+    exact, prefixes = reach
+    return path in exact or path.startswith(prefixes)
+
+
 def _scope_matchers(scopes: tuple[Scope, ...]) -> tuple[_ScopeMatch, ...]:
     return tuple(
-        _ScopeMatch(s.name, frozenset(s.paths),
-                    tuple(p.rstrip("/") + "/" for p in s.paths),
-                    _source_extensions(s.languages))
+        _ScopeMatch(s.name, *scope_reach(s.paths), _source_extensions(s.languages))
         for s in scopes
     )
 
@@ -86,7 +104,7 @@ def _owning_scope(path: str, matchers: tuple[_ScopeMatch, ...]) -> str | None:
     # a prefix-only match must not stop the search or shared-prefix scopes
     # silently black-hole each other's files.
     for m in matchers:
-        if path in m.exact or path.startswith(m.prefixes):
+        if in_scope_reach((m.exact, m.prefixes), path):
             if path.endswith(m.extensions):
                 return m.name
     return None

--- a/tests/e2e/test_init_doctor_e2e.py
+++ b/tests/e2e/test_init_doctor_e2e.py
@@ -407,3 +407,44 @@ def test_ratchet_seed_then_prune_lifecycle(tight_repo: Path):
                  if not ln.startswith("#")]  # the metric stamp survives an emptied ratchet
     assert remaining == ["path\tlong_name\tcrap"]
     assert "pruned" in pruned.stdout
+
+
+# --- the environment the scaffolded lane binds to -----------------------------
+
+@pytest.fixture()
+def locked_repo(tmp_path: Path) -> Path:
+    """A pytest project that pins its environment with uv, which is the shape
+    two worktrees of one branch are usually checked out in."""
+    repo = tmp_path / "locked"
+    (repo / "pylib").mkdir(parents=True)
+    (repo / "pylib" / "mod.py").write_text("def g(x):\n    return x or 0\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text('[project]\nname = "faro"\n', encoding="utf-8")
+    (repo / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    _git_commit_all(repo, "init")
+    return repo
+
+
+def test_init_binds_the_lane_to_the_environment_the_lockfile_pins(locked_repo: Path):
+    """A bare `python` binds to whatever venv the shell has active. Run in one
+    worktree with another worktree's venv active, that lane measures the other
+    checkout — and when the two APIs agree it does so silently."""
+    res = run_cli(locked_repo, "init")
+    assert res.returncode == 0, res.stderr
+
+    from crapkit.config import load_config_text
+    cfg = load_config_text((locked_repo / "crapkit.toml").read_text(encoding="utf-8"))
+    (lane,) = cfg.lanes
+    assert lane.command.startswith("uv run python -m pytest ")
+    assert dict(cfg.scoped_tests)["pylib"].startswith("uv run python -m pytest ")
+
+
+def test_the_same_project_without_a_lockfile_keeps_the_bare_interpreter(locked_repo: Path):
+    (locked_repo / "uv.lock").unlink()
+    _git_commit_all(locked_repo, "drop the lockfile")
+
+    assert run_cli(locked_repo, "init").returncode == 0
+
+    from crapkit.config import load_config_text
+    cfg = load_config_text((locked_repo / "crapkit.toml").read_text(encoding="utf-8"))
+    assert re.match(r"python3? -m pytest ", cfg.lanes[0].command)

--- a/tests/e2e/test_lane_artifact_scope_e2e.py
+++ b/tests/e2e/test_lane_artifact_scope_e2e.py
@@ -1,0 +1,80 @@
+"""End-to-end: an artifact about another checkout never becomes a grade.
+
+The near-miss behind this. Two git worktrees of one repo, and a shell holding
+the OTHER worktree's venv, whose editable install points at that checkout's
+sources. The lane runs here, coverage.py measures there, and because the file
+lives outside this tree it is reported by absolute path. Had the two checkouts'
+APIs matched, the suite would have passed, the join would have found nothing,
+and `coverage` would have printed a confident "N untested … grade F" that was
+entirely an artifact of the wrong venv.
+
+Real git, real CLI. The istanbul lane is the hermetic one, so it plays the part.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+# make_cov.py, but writing about a sibling checkout instead of this one — the
+# shape coverage.py and istanbul both produce for a file outside the tree.
+ELSEWHERE = (
+    "import json, os\n"
+    "root = os.path.dirname(os.getcwd())\n"
+    "app = os.path.join(root, 'other-checkout', 'src', 'app.ts').replace(os.sep, '/')\n"
+    "artifact = {app: {'path': app,\n"
+    "    'fnMap': {'0': {'name': 'dispatch', 'decl': {'start': {'line': 1}},\n"
+    "                    'loc': {'start': {'line': 1}, 'end': {'line': 10}}}},\n"
+    "    'f': {'0': 3},\n"
+    "    'branchMap': {'0': {'loc': {'start': {'line': 2}},\n"
+    "                        'locations': [{'start': {'line': 2}}, {'start': {'line': 3}}]}},\n"
+    "    'b': {'0': [1, 1]}}}\n"
+    "os.makedirs(os.path.join(os.getcwd(), 'coverage'), exist_ok=True)\n"
+    "open(os.path.join('coverage', 'coverage-final.json'), 'w', encoding='utf-8')"
+    ".write(json.dumps(artifact))\n"
+)
+
+
+def run_cli(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, "-m", "crapkit", *args], cwd=repo,
+                          capture_output=True, text=True, timeout=180, env=dict(os.environ))
+
+
+@pytest.fixture()
+def wrong_tree_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "mini"
+    shutil.copytree(FIXTURES / "mini_repo", repo)
+    (repo / "make_cov.py").write_text(ELSEWHERE, encoding="utf-8")
+    (repo / ".gitignore").write_text(
+        ".crapkit/\ncoverage/\ncoverage-py.json\njunit.xml\n__pycache__/\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
+                    "-m", "init"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def test_a_lane_measuring_another_checkout_fails_instead_of_grading_it(wrong_tree_repo: Path):
+    res = run_cli(wrong_tree_repo, "coverage", "--json")
+
+    assert res.returncode == 5, res.stderr
+    assert "lane 'unit' FAILED" in res.stderr
+    assert "none of them under the paths its scopes declare" in res.stderr
+    assert "other-checkout/src/app.ts" in res.stderr, "the paths it did measure are quoted"
+
+
+def test_the_scope_that_lane_claimed_reads_as_a_tooling_gap_not_as_untested(
+        wrong_tree_repo: Path):
+    """The distinction the whole finding is about. `untested` says nobody wrote
+    a test; `no-lane` says nothing measured this. A refused lane must produce
+    the second, and the second is what keeps the grade honest."""
+    summary = json.loads(run_cli(wrong_tree_repo, "coverage", "--json").stdout)
+
+    assert summary["no_lane"] > 0
+    assert summary["untested"] == 0
+    assert summary["lane_failures"]["unit"]

--- a/tests/unit/test_init_detection.py
+++ b/tests/unit/test_init_detection.py
@@ -8,7 +8,7 @@ import json
 
 from crapkit.config import load_config_text
 from crapkit.scaffold import (detect_lanes, gitignore_entries, gitignore_update, live_lanes,
-                              source_candidates, starter_toml)
+                              lockfile_runner, python_launcher, source_candidates, starter_toml)
 
 SCOPES = {"pylib": ("python",), "src": ("typescript",)}
 
@@ -319,3 +319,63 @@ def test_an_undetected_runner_keeps_its_scoped_tests_entry_commented():
     assert "src" in dict(cfg.scoped_tests)
     assert "ui" not in dict(cfg.scoped_tests)
     assert '# ui = "npx vitest run {files}"' in text
+
+
+# --- the environment the scaffolded lane binds to -----------------------------
+#
+# `python -m pytest` binds to whatever venv the shell has active. In two
+# worktrees of one branch that is how a lane run in checkout A imports checkout
+# B's sources through B's editable install — which either dies in collection or,
+# when the two APIs agree, measures B and scores A as untested. A lockfile is the
+# repo saying which environment is the right one, and the manager's `run` is the
+# only spelling that binds to it.
+
+def test_a_uv_lock_pins_the_lane_to_the_projects_own_environment():
+    (lane,) = detect_lanes(frozenset({"pyproject.toml"}), "", interpreter="uv run python")
+
+    assert lane.command == ("uv run python -m pytest --cov --cov-branch "
+                            "--cov-report=json:.crapkit/cov/py.json")
+
+
+def test_each_lockfile_names_the_manager_that_owns_the_environment():
+    assert lockfile_runner(frozenset({"uv.lock"})) == "uv run"
+    assert lockfile_runner(frozenset({"poetry.lock"})) == "poetry run"
+    assert lockfile_runner(frozenset({"pdm.lock"})) == "pdm run"
+    assert lockfile_runner(frozenset({"Pipfile.lock"})) == "pipenv run"
+
+
+def test_no_lockfile_leaves_the_interpreter_alone():
+    assert lockfile_runner(frozenset({"package-lock.json", "Cargo.lock"})) == ""
+
+
+def test_two_lockfiles_resolve_the_same_way_every_time():
+    """A repo mid-migration carries both. Declaration order decides, so the
+    config init writes does not depend on which name a set iterated first."""
+    assert lockfile_runner(frozenset({"poetry.lock", "uv.lock"})) == "uv run"
+
+
+def test_the_scoped_tests_entry_runs_the_same_python_the_lane_does():
+    """Step 3 measuring one environment and step 4 testing another is the same
+    bug one command later."""
+    lanes = detect_lanes(frozenset({"pyproject.toml"}), "", interpreter="uv run python")
+
+    cfg = load_config_text(starter_toml({"src": ("python",)}, lanes))
+
+    assert dict(cfg.scoped_tests)["src"] == (
+        "uv run python -m pytest {files} -q -p no:cacheprovider")
+
+
+def test_the_launcher_is_read_back_off_the_lane_rather_than_guessed():
+    assert python_launcher(detect_lanes(frozenset({"pytest.ini"}), "",
+                                        interpreter="poetry run python")) == "poetry run python"
+    assert python_launcher(()) == "python", "no pytest lane, no claim to make"
+    assert python_launcher(detect_lanes(frozenset(), _package(scripts={"test": "vitest run"}))) \
+        == "python", "a js lane says nothing about python"
+
+
+def test_a_managed_lane_still_reads_as_the_confirmed_pytest_runner():
+    """The `-m pytest` shape is what marks the python scoped-tests entry live;
+    a manager prefix in front of it must not retire that."""
+    lanes = detect_lanes(frozenset({"pyproject.toml"}), "", interpreter="pdm run python")
+
+    assert "src" in dict(load_config_text(starter_toml({"src": ("python",)}, lanes)).scoped_tests)

--- a/tests/unit/test_init_probe.py
+++ b/tests/unit/test_init_probe.py
@@ -91,3 +91,55 @@ def test_only_a_cov_flagged_coveragepy_lane_is_probed(lane, monkeypatch, capsys)
     monkeypatch.setattr(admin, "_pytest_cov_probe", boom)
     _warn_missing_pytest_cov((lane,))
     assert capsys.readouterr().err == ""
+
+
+# --- a lane headed by an environment manager ---------------------------------
+#
+# `uv run python -m pytest` heads on `uv`, and `uv -c "import pytest_cov"` is not
+# a python invocation at all: it exits non-zero and the probe would warn about
+# pytest-cov on every uv repo. Probing the real thing is worse — `uv run` and its
+# siblings CREATE or sync the project environment first, and init has no business
+# provisioning one to ask a question about it.
+
+@pytest.mark.parametrize("command", [
+    "uv run python -m pytest --cov",
+    "poetry run python -m pytest --cov",
+    "pdm run python -m pytest --cov",
+    "pipenv run python -m pytest --cov",
+])
+def test_a_manager_headed_lane_is_left_alone(command, monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("init must not run the manager to ask a question")
+
+    monkeypatch.setattr("subprocess.run", boom)
+    assert _pytest_cov_probe(command) is True
+
+
+def test_a_managed_lane_prints_no_pytest_cov_warning(capsys):
+    _warn_missing_pytest_cov((_lane("uv run python -m pytest --cov"),))
+
+    assert capsys.readouterr().err == ""
+
+
+# --- which interpreter init writes into the config ---------------------------
+
+def _repo(tmp_path, *names: str):
+    for name in names:
+        (tmp_path / name).write_text("", encoding="utf-8")
+    return tmp_path
+
+
+def test_a_lockfile_makes_init_write_the_managers_own_python(tmp_path):
+    assert admin._interpreter(_repo(tmp_path, "uv.lock")) == "uv run python"
+    assert admin._interpreter(_repo(tmp_path, "poetry.lock")) == "uv run python", \
+        "first match wins, and uv.lock is still there"
+
+
+def test_without_a_lockfile_the_name_that_resolves_is_the_one_written(tmp_path):
+    assert admin._interpreter(_repo(tmp_path, "Cargo.lock")) in ("python", "python3")
+
+
+def test_the_lockfiles_init_reads_are_the_ones_it_looks_for(tmp_path):
+    _repo(tmp_path, "pdm.lock", "package-lock.json")
+
+    assert admin._present_lockfiles(tmp_path) == frozenset({"pdm.lock"})

--- a/tests/unit/test_lane_scope_overlap.py
+++ b/tests/unit/test_lane_scope_overlap.py
@@ -1,0 +1,158 @@
+"""A lane's artifact has to be about THIS checkout, and a lane is where that is asked.
+
+Coverage joins on path and nothing else. An artifact whose measured paths reach
+none of the scopes its lane claims contributes exactly nothing, and every
+function in those scopes then scores `untested` — a confident "N untested,
+grade F" assembled entirely out of a tooling mistake. Two worktrees of one
+branch reach it quietly: a venv whose editable install points at the other
+checkout makes coverage.py measure that tree and report it in absolute paths.
+
+Zero overlap is the whole test — a partial overlap has honest readings, and any
+threshold over zero would need tuning per repo — but zero has two readings, and
+the measured paths tell them apart. Files outside this checkout can only be
+another tree, and that fails the lane. In-tree paths that simply miss the scopes
+are also the greenfield shape, a suite importing none of the scoped source yet,
+which SHOULD score untested; that one warns and scores on.
+"""
+import json
+
+import pytest
+
+from crapkit.config import Lane
+from crapkit.errors import ToolError
+from crapkit.lanes import run_lane
+
+OTHER = "/Users/dev/checkout-b/src/faro/core.py"
+
+
+def _functions() -> dict:
+    return {"functions": {"widget": {
+        "start_line": 1, "executed_lines": [1], "missing_lines": [],
+        "summary": {"covered_lines": 1, "num_statements": 1,
+                    "num_branches": 2, "covered_branches": 2}}}}
+
+
+def _artifact(tmp_path, *paths: str) -> None:
+    report = {"meta": {"branch_coverage": True},
+              "files": {path: _functions() for path in paths}}
+    (tmp_path / "cov.json").write_text(json.dumps(report), encoding="utf-8")
+
+
+def _lane(scopes=("src",), path_prefix: str = "") -> Lane:
+    return Lane(name="py", command="true", artifact="cov.json", parser="coveragepy",
+                scopes=scopes, path_prefix=path_prefix)
+
+
+def _run(tmp_path, lane: Lane, scope_paths):
+    return run_lane(tmp_path, lane, reuse_artifact=True, scope_paths=scope_paths)
+
+
+def test_an_artifact_that_measured_another_checkout_is_refused(tmp_path):
+    _artifact(tmp_path, OTHER)
+
+    with pytest.raises(ToolError) as raised:
+        _run(tmp_path, _lane(), {"src": ("src",)})
+
+    assert "none of them under the paths its scopes declare" in str(raised.value)
+    assert "describes a different tree" in str(raised.value)
+
+
+@pytest.mark.parametrize("elsewhere", ["/abs/src/core.py", "../sibling/src/core.py",
+                                       "C:/checkout-b/src/core.py"])
+def test_every_spelling_of_a_path_outside_the_tree_is_refused(tmp_path, elsewhere):
+    """Both parsers rebase a file inside the repo to a repo-relative path, so a
+    path that stayed absolute, drive-lettered or climbing is a file elsewhere."""
+    _artifact(tmp_path, elsewhere)
+
+    with pytest.raises(ToolError, match="different tree"):
+        _run(tmp_path, _lane(), {"src": ("src",)})
+
+
+def test_the_refusal_quotes_the_paths_the_artifact_does_name(tmp_path):
+    """Without them the reader cannot tell a wrong tree from a wrong prefix."""
+    _artifact(tmp_path, OTHER)
+
+    with pytest.raises(ToolError) as raised:
+        _run(tmp_path, _lane(), {"src": ("src",)})
+
+    assert OTHER in str(raised.value)
+    assert "path_prefix" in str(raised.value), "the legitimate remapping knob is named"
+
+
+def test_one_file_in_reach_is_enough_to_let_the_artifact_through(tmp_path):
+    """A lane measuring part of what it claims is ordinary; only zero is not."""
+    _artifact(tmp_path, OTHER, "src/faro/core.py")
+
+    coverage, _, _ = _run(tmp_path, _lane(), {"src": ("src",)})
+
+    assert "src/faro/core.py" in coverage
+
+
+def test_a_scope_that_declares_individual_files_is_reached_exactly(tmp_path):
+    """Scope paths may name files, not only directories, and a prefix test alone
+    calls every one of them unreachable."""
+    _artifact(tmp_path, "src/faro/core.py")
+
+    coverage, _, _ = _run(tmp_path, _lane(), {"src": ("src/faro/core.py",)})
+
+    assert list(coverage) == ["src/faro/core.py"]
+
+
+def test_the_prefix_the_lane_declares_is_applied_before_the_question(tmp_path):
+    """path_prefix is the remapping the message points at, so an artifact it
+    rescues must not be refused on the paths it had before."""
+    _artifact(tmp_path, "faro/core.py")
+
+    coverage, _, _ = _run(tmp_path, _lane(path_prefix="src"), {"src": ("src",)})
+
+    assert list(coverage) == ["src/faro/core.py"]
+
+
+def test_in_tree_paths_that_miss_the_scope_warn_rather_than_fail(tmp_path, capsys):
+    """The greenfield shape: a suite that imports none of the scoped source yet.
+    `untested` is the right answer there, and refusing it would exit 5 on exactly
+    the repos that are adopting crapkit."""
+    _artifact(tmp_path, "tests/test_core.py")
+
+    coverage, _, _ = _run(tmp_path, _lane(), {"src": ("src",)})
+
+    assert list(coverage) == ["tests/test_core.py"]
+    err = capsys.readouterr().err
+    assert "will score untested" in err and "tests/test_core.py" in err
+    assert "path_prefix" in err
+
+
+def test_an_artifact_that_measured_nothing_at_all_warns_too(tmp_path, capsys):
+    """A coverage.py run that imported no scoped source writes an empty report,
+    and that is the same greenfield shape one step further along."""
+    _artifact(tmp_path)
+
+    _run(tmp_path, _lane(), {"src": ("src",)})
+
+    assert "measured 0 file(s)" in capsys.readouterr().err
+
+
+def test_a_reached_scope_says_nothing_at_all(tmp_path, capsys):
+    _artifact(tmp_path, "src/faro/core.py")
+
+    _run(tmp_path, _lane(), {"src": ("src",)})
+
+    assert capsys.readouterr().err == ""
+
+
+def test_a_lane_whose_scopes_declare_no_path_is_not_judged(tmp_path, capsys):
+    """Nothing to compare against is not evidence of a mismatch."""
+    _artifact(tmp_path, OTHER)
+
+    coverage, _, _ = _run(tmp_path, _lane(scopes=()), {"src": ("src",)})
+
+    assert list(coverage) == [OTHER]
+    assert capsys.readouterr().err == ""
+
+
+def test_a_caller_that_passes_no_scope_paths_is_not_judged(tmp_path):
+    _artifact(tmp_path, OTHER)
+
+    coverage, _, _ = run_lane(tmp_path, _lane(), reuse_artifact=True)
+
+    assert list(coverage) == [OTHER]

--- a/tests/unit/test_lanes.py
+++ b/tests/unit/test_lanes.py
@@ -51,3 +51,113 @@ def test_no_private_project_namespace_ships_in_the_library():
                     if "COVMARK" in p.read_text(encoding="utf-8"))
 
     assert leaked == []
+
+
+# --- what a failing lane tells you about where the rest of the story is -------
+#
+# A reporter running 0.4.4 against a real repo saw only a 500-BYTE tail that
+# began mid-line — "short test summary info ====" — with ten collection
+# tracebacks cut off above it and nothing naming .crapkit/lane-py.log. Finding
+# the log took another agent. Three things fix that: the path, a tail cut on
+# line boundaries, and the reason lines when the end of the log has none.
+
+def _plant_log(tmp_path, lines: list[str]) -> Path:
+    log = tmp_path / ".crapkit" / "lane-py.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("\n".join(lines), encoding="utf-8")
+    return log
+
+
+def _py_lane() -> Lane:
+    return Lane(name="py", command="python -m pytest --cov", artifact=".crapkit/cov/py.json",
+                parser="coveragepy", scopes=("src",))
+
+
+def _refusal(tmp_path, lines: list[str]) -> str:
+    from crapkit.lanes import _raise_no_artifact
+
+    log = _plant_log(tmp_path, lines)
+    with pytest.raises(ToolError) as raised:
+        _raise_no_artifact(_py_lane(), log, 2)
+    return str(raised.value)
+
+
+def test_the_refusal_names_the_log_file_that_holds_the_whole_story(tmp_path):
+    message = _refusal(tmp_path, ["$ python -m pytest --cov", "boom", "(exit 2)"])
+
+    assert str(tmp_path / ".crapkit" / "lane-py.log") in message
+
+
+def test_a_lane_that_runs_and_writes_nothing_names_its_log_too(tmp_path):
+    """Through the real runner, not just the message builder."""
+    lane = Lane(name="dead", command=f'"{sys.executable}" -c "import sys; sys.exit(9)"',
+                artifact="cov.json", parser="istanbul", scopes=())
+    with pytest.raises(ToolError) as raised:
+        run_lane(tmp_path, lane)
+
+    assert str(tmp_path / ".crapkit" / "lane-dead.log") in str(raised.value)
+
+
+def test_the_tail_begins_at_a_line_boundary(tmp_path):
+    """A byte tail starts mid-line, and the reader cannot tell that fragment
+    from the real first word of the message."""
+    lines = [f"line {i:03d} " + "x" * 60 for i in range(40)]
+    message = _refusal(tmp_path, lines)
+
+    shown = message.split("; last output: ", 1)[1].splitlines()
+    assert shown, "the tail is the point of the message"
+    assert set(shown) <= set(lines), "a shown line is a whole line of the log"
+    assert shown[-1] == lines[-1]
+
+
+def test_the_reason_survives_a_summary_block_long_enough_to_bury_it(tmp_path):
+    """pytest ends on a summary saying WHICH files broke and never why. The
+    reason sits above it, and on a wide enough collection failure the byte
+    budget never reaches it."""
+    lines = ["$ python -m pytest --cov",
+             "tests/test_a.py:3: in <module>",
+             "    from faro.core import Widget",
+             "E   ImportError: cannot import name 'Widget' from '/other/checkout/src'",
+             "=========================== short test summary info ============================"]
+    lines += [f"ERROR tests/test_{i:03d}.py" for i in range(60)]
+    lines += ["============================== 60 errors in 0.6s ===============================",
+              "(exit 2)"]
+
+    message = _refusal(tmp_path, lines)
+
+    assert "cannot import name 'Widget' from '/other/checkout/src'" in message
+    assert "short test summary info" not in message, "the budget went to the reason"
+
+
+def test_a_tail_that_already_says_why_is_not_repeated(tmp_path):
+    lines = ["$ python -m pytest --cov", "E   ImportError: no module named 'faro'", "(exit 2)"]
+
+    message = _refusal(tmp_path, lines)
+
+    assert message.count("no module named 'faro'") == 1
+
+
+def test_the_pytest_cov_hint_still_fires_through_the_new_tail(tmp_path):
+    lines = ["$ python -m pytest --cov",
+             "pytest: error: unrecognized arguments: --cov --cov-branch", "(exit 4)"]
+
+    assert "pip install pytest-cov" in _refusal(tmp_path, lines)
+
+
+def test_one_line_longer_than_the_budget_says_it_was_cut(tmp_path):
+    message = _refusal(tmp_path, ["y" * 4000])
+
+    assert "; last output: ..." in message, "an ellipsis marks the one cut a tail cannot avoid"
+
+
+def test_a_refusal_with_no_log_at_all_still_names_where_it_would_be(tmp_path):
+    """Nothing writes the log before the command runs, and a lane refused ahead
+    of that has no tail to quote. The path is the half that always applies."""
+    from crapkit.lanes import _raise_no_artifact
+
+    missing = tmp_path / ".crapkit" / "lane-py.log"
+    with pytest.raises(ToolError) as raised:
+        _raise_no_artifact(_py_lane(), missing, None)
+
+    assert str(missing) in str(raised.value)
+    assert "last output" not in str(raised.value), "no log, nothing to quote"


### PR DESCRIPTION
Three findings from running 0.4.4 against a real pytest/uv project checked out twice through git worktrees.

**20 files · +923/−43 · 35 new tests · 2478 passed, 14 skipped · `crapkit verify` OK**

**The incident was not a crapkit bug.** The shell held checkout B's venv while crapkit ran in checkout A; that venv's editable install pointed at B's `src`, so A's tests imported B's source and pytest died with ten collection `ImportError`s. Correct diagnosis, user-side fix. But crapkit made it far harder to find than it should have been, and was one step away from turning it into a silent wrong answer.

What crapkit *is* responsible for is how that looked from the outside:

```
crapkit: lane 'py' FAILED: lane 'py' produced no artifact at
.crapkit/cov/py.json (command exit 2); last output:  short test summary
info ============================
```

Ten `ImportError` tracebacks, each naming the offending checkout path, sat immediately above that cut. Nothing said `.crapkit/lane-py.log` existed. Finding it took a second agent.

### The near-miss

Those imports failed loudly **only because the two checkouts' APIs had diverged**. Had they matched — the ordinary case for two worktrees of one branch — this is the path crapkit would have taken:

| # | Step | What happens |
|---|---|---|
| 1 | lane runs | pytest under B's venv, measures B's `src` |
| 2 | artifact | paths are absolute — B is outside A's tree |
| 3 | join | 0 of A's scoped files match any measured path |
| 4 | score | every function reads `cov = 0` |
| 5 | **verdict** | **`N untested … grade F`** — pure fiction, **exit 0** |

---

## A. A failing lane now says where its log is

`_raise_no_artifact` took `log_path` and never printed it.

```diff
-read_text().strip()[-500:]            # byte slice, opens mid-line
+_tail_lines(lines, 500)               # whole lines only
+_cause_lines(lines, tail)             # the reason, when the tail has none

-f"…{detail}{hint}"
+f"…{detail}; full log: {log_path}{hint}"
```

Three changes:

- every no-artifact refusal carries `full log: <path>`;
- the tail is cut on **line boundaries**, so it can no longer open on a fragment that reads like the start of a message (one line longer than the budget on its own keeps its end behind an ellipsis, which at least says so);
- when the end of the log names no cause — pytest closes on a summary block of `ERROR path` lines saying *which* files broke and never *why* — the last few lines that **do** name one are hoisted in front of it, with an `...` marking the output skipped between them.

The same failure now prints:

```
crapkit: lane 'py' FAILED: lane 'py' produced no artifact at .crapkit/cov/py.json
(command exit 2); full log: /repo/.crapkit/lane-py.log; last output:
E   ImportError: cannot import name 'Widget' from 'faro.core' (/other/checkout/src/faro/core.py)
...
ERROR tests/test_widgets.py
============================== 10 errors in 0.62s ==============================
```

That hoisted line carries the other checkout's absolute path — it would have blown the original case open on sight.

## B. An artifact that measured a different tree is refused, not scored

Nothing checked that a lane's artifact was about this checkout; `parse_coveragepy_file` applied only the optional `path_prefix`. Coverage joins on path and nothing else, so an artifact whose paths reach none of the scopes its lane claims contributes exactly nothing and every function in those scopes reads `untested` — a confident `N untested … grade F` assembled out of a tooling mistake, which is worse than the exit 5 a missing artifact already earns, because it looks like an answer.

**Two verdicts, because zero overlap has two readings and the measured paths tell them apart:**

| Measured paths | Reading | Verdict |
|---|---|---|
| `/other/checkout/src/a.py`, `../sibling/src/a.py`, `C:/b/src/a.py` | Outside this checkout. Both parsers rebase in-tree files to repo-relative paths, so a path that stayed absolute, drive-lettered or climbing is a file somewhere else. | **fail the lane** — exit 5; scopes fall back to `no-lane`, not `untested` |
| `tests/test_core.py`, or nothing at all | In-tree, just not under the scope. Also the greenfield shape: a suite importing none of the scoped source *yet*. | **warn, score on** — `untested` is the honest answer |

The refusal:

```
crapkit: lane 'py' FAILED: lane 'py' measured 412 file(s), none of them under
the paths its scopes declare (src/), and 412 of them outside this checkout
entirely — .crapkit/cov/py.json describes a different tree, so joining it would
score every function in those scopes untested; it reports paths like
/Users/x/checkout-b/src/faro/core.py. Point the lane at this checkout's own
environment (a bare `python -m pytest` binds to whichever venv the shell has
active — run it through the project's manager, `uv run python -m pytest ...`),
or set path_prefix when the runner reports paths relative to a subdirectory
```

and the warning:

```
crapkit: lane 'py' measured 12 file(s), none of them under the paths its scopes
declare (src/), so every function in those scopes will score untested; it
measured tests/test_core.py — either nothing in them is exercised yet, or the
runner reports paths this lane needs path_prefix to rebase
```

**Why the split exists — the suite forced it.** The first cut failed on any zero overlap. That broke `test_worklist_surface_e2e.py`, whose fixture writes an empty artifact on purpose: *"absent or empty plan means every function reads as untested, which is what an uncovered fixture wants."* Refusing that would have exited 5 on exactly the repos adopting crapkit. The path shape separates the two, and separates them exactly.

**Why zero and not "near zero".** A partial overlap has honest readings — a lane measuring part of a scope, generated files outside it — and any threshold over zero would need tuning per repo. Zero has one cause and no reading under which the join was ever going to work.

**Where it lives.** In `run_lane`, where both halves of the question are already in hand, and after `path_prefix` has been applied — so a prefix that fixes the join is never refused. It reuses a new `universe.scope_reach`, shared with `_owning_scope`'s assignment rule, so the "could a scope claim this path?" test can never drift from the one that assigns files. That also picks up the **exact-path** half of the rule, which a prefix-only test would have got wrong for a scope declaring individual files rather than directories.

## C. `init` binds the lane to the environment the repo pins

The root cause of the whole report. The scaffolded lane was a bare `python -m pytest`, which resolves through `PATH` to whichever venv is active. crapkit already "detects lanes from this repo's own files"; a lockfile is one more such file.

| Lockfile at root | Lane command |
|---|---|
| `uv.lock` | `uv run python -m pytest --cov …` |
| `poetry.lock` | `poetry run python -m pytest --cov …` |
| `pdm.lock` | `pdm run python -m pytest --cov …` |
| `Pipfile.lock` | `pipenv run python -m pytest --cov …` |
| none | `python -m pytest --cov …` (or `python3`), unchanged |

- **First match wins**, in that order, so a repo mid-migration between two managers gets the same config every time.
- **`[crapkit.scoped_tests]` takes the same prefix**, read back off the lane rather than passed in beside it: step 3 measuring one environment while step 4 tests another is the same bug one command later.
- **A manager-headed lane is not probed for pytest-cov.** `uv run` and its siblings create or sync the project environment before running anything, and `init` has no business provisioning one to ask a question about it. The old probe would also have run `uv -c "import pytest_cov"` — not a python invocation at all — and warned about the wrong gap on every uv repo.

Verified by hand before it was written down: in the checkout that had just failed, `uv run --with pytest-cov python -m pytest -m 'not live and not perf' --cov …` scored **351/351 measured**.

---

## Also verified working, no action taken

0.4.4's shlex lane lint accepts an inline quoted marker expression (`-m 'not live and not perf'`), and the pytest-cov hint fired correctly on a fresh repo. Both good.

## Testing

Per AGENTS.md, every new behaviour lands with a test that fails on the parent commit. The parent tree was extracted with `git archive HEAD` and the new tests run against it.

| Check | Result |
|---|---|
| New unit + e2e tests on parent `e8b35f7` | 13 fail — the reproducers reproduce |
| Same tests on this branch | all pass |
| Finding B e2e on parent | `exit 0, "untested": 3` — the silent wrong answer, verbatim |
| Full suite | **2478 passed, 14 skipped** |
| `crapkit hook-precommit` (staged, ccn ≤ 6) | exit 0 |
| `crapkit coverage` on itself | 1193 measured / 0 untested, 1 over target, grade A |
| `crapkit verify` on itself | verify OK, exit 0 |

Docs moved with the code: two new sections in `docs/lanes.md` (*The interpreter a lane binds to*, *An artifact that measured a different tree*), the exit-5 rows in `README.md` / `AGENTS.md` / `docs/handbook.html`, a new triage table in the `crapkit-recover` skill, `CHANGELOG` 0.4.5 and the three version stamps.

## One thing found on the way, deliberately not fixed here

**pytest-cov 7 silently kills this repo's subprocess coverage.** The e2e tests drive the CLI through `subprocess.run`, and `crapkit.toml` comments say the `--cov=crapkit` spelling exists precisely to make that work.

| pytest-cov | `cmd_init` coverage | Effect on `crapkit verify` |
|---|---|---|
| `7.1.0` | **0 %** | every CLI entry point reads 0 %; the gate fires on any touched `cmd_*` |
| `6.3.0` | **100 %** | correct — but 4 import-cost tests then fail under the lane |

Under 6.3.0 the four are `test_config_shape::test_reading_the_config_module_costs_no_dataclasses_import`, `test_pygments_deferral` (both), and `test_version_metadata_cost::test_an_agreeing_distribution_answers_without_importing_metadata` — active subprocess coverage imports what they assert is absent.

Both reproduce unchanged on `e8b35f7`, so neither is caused by this PR. `dev = ["pytest-cov>=5"]` is unpinned, so a fresh `pip install -e ".[dev]"` today gets 7.x and the dogfood job quietly under-measures itself; CI's `verify … || true` is why nothing has flagged it. Happy to open a separate issue or PR if you want it chased — it seemed wrong to fold a dependency-pin decision into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5zNxe1t2jrfb37kTrhjQ7
