### PR TITLE
Install the action's crapkit editable, so a self-measuring lane sees the tree

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,9 +33,14 @@ runs:
     # consumer pinned in `uses:`. Installing from it is what makes
     # `crapkit@v0.4.8` mean the 0.4.8 code: `pip install crapkit` here would
     # score every consumer with whatever released last, whatever they pinned.
+    # Editable, because a regular install replaces an editable one of the same
+    # package that the consumer's own setup step made, and when that consumer
+    # is crapkit itself (`uses: ./`) the lane's `--cov=crapkit` then measures the
+    # copy in site-packages: 61 files outside the checkout, and the wrong-tree
+    # refusal failed the lane on the first run of this action.
     - name: install crapkit from this action's own checkout
       shell: bash
-      run: pip install "$GITHUB_ACTION_PATH"
+      run: pip install -e "$GITHUB_ACTION_PATH"
 
     # Every step below keeps its own status at 0 and records what it got. The
     # comment is this action's output, and a job that dies at step three posts

--- a/tests/unit/test_action_contract.py
+++ b/tests/unit/test_action_contract.py
@@ -174,6 +174,10 @@ def test_the_action_installs_crapkit_from_its_own_checkout():
 
     assert "pip install" in joined
     assert "GITHUB_ACTION_PATH" in joined, "the install must name the action's own checkout"
+    assert 'pip install -e "$GITHUB_ACTION_PATH"' in joined, (
+        "the install must be editable: a regular install replaces a consumer's editable "
+        "install of the same package, and when that consumer is crapkit itself the lane's "
+        "--cov=crapkit then measures site-packages, which the wrong-tree refusal rejects")
 
 
 # --- the sticky comment ------------------------------------------------------


### PR DESCRIPTION
The first run of the action on this repository failed its own lane. The
dogfood job installs the repo editable, then the action ran
pip install "$GITHUB_ACTION_PATH", which replaced that editable install
with a regular one; the lane's --cov=crapkit then measured the copy in
site-packages, 61 files outside the checkout, and the wrong-tree refusal
that 0.4.7 added did exactly what it is for: exit 5, no run, no verdict.
An editable install keeps the measured paths in the tree for a repository
that measures itself, and changes nothing for a consumer whose lanes
measure their own code. The contract went red on the plain install first.

This pull request also exercises the action's own comment path on a pull request for the first time: the dogfood job should post one sticky comment and edit it in place on any later push.